### PR TITLE
feat: Upgrade virksert dependencies, remove unnecessary extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ copy the URL directly into a Browser of REST client
 * The organisations that are managed by KS is hard coded in lack of a cental lookup service, the managed organsations are 910951688 and 910076787. A new Implementation of the KSLookup interface can be created when- and if a  central service becomes available.    
 * The persistent store for keeping how organisations want to receive messages (primary service) is kept in-memory at (as a map) the moment. This functionality might not be relevant for a production scenario - so very little effort went into it.  
 
-# Depenencies
+# Dependencies
 
-Please note, as of 7.4.2016:
+Please note, as of 16.11.2020:
 To build this module you need to have the following non public modules in your local maven repository
 
 ```xml
           <dependency>
               <groupId>no.difi.virksert</groupId>
               <artifactId>virksert-common</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>1.3.3</version>
           </dependency>
           <dependency>
               <groupId>no.difi.virksert</groupId>
               <artifactId>virksert-client</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>1.3.3</version>
           </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,17 +204,12 @@
             <dependency>
                 <groupId>no.difi.virksert</groupId>
                 <artifactId>virksert-common</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>1.3.3</version>
             </dependency>
             <dependency>
                 <groupId>no.difi.virksert</groupId>
                 <artifactId>virksert-client</artifactId>
-                <version>1.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>no.difi.virksert</groupId>
-                <artifactId>virksert-move</artifactId>
-                <version>1.0.3-SNAPSHOT</version>
+                <version>1.3.3</version>
             </dependency>
 
             <dependency>
@@ -300,23 +295,15 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <move-common.version>1.1.5</move-common.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <kotlin.version>1.3.61</kotlin.version>
+        <virksert.version>1.3.3</virksert.version>
     </properties>
 
     <modules>
@@ -204,12 +205,12 @@
             <dependency>
                 <groupId>no.difi.virksert</groupId>
                 <artifactId>virksert-common</artifactId>
-                <version>1.3.3</version>
+                <version>${virksert.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.difi.virksert</groupId>
                 <artifactId>virksert-client</artifactId>
-                <version>1.3.3</version>
+                <version>${virksert.version}</version>
             </dependency>
 
             <dependency>

--- a/serviceregistry-server/pom.xml
+++ b/serviceregistry-server/pom.xml
@@ -357,10 +357,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>no.difi.virksert</groupId>
-            <artifactId>virksert-move</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/service/virksert/VirkSertService.java
+++ b/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/service/virksert/VirkSertService.java
@@ -51,7 +51,7 @@ public class VirkSertService {
             if (env.acceptsProfiles(Profiles.of("production"))) {
                 virksertClient = BusinessCertificateClient.of(virksertUrl, Mode.PRODUCTION);
             } else {
-                virksertClient = BusinessCertificateClient.of(virksertUrl, "/recipe-move-difiSigned.xml");
+                virksertClient = BusinessCertificateClient.of(virksertUrl, Mode.MOVE);
             }
         } catch (BusinessCertificateException e) {
             throw new ServiceRegistryException(e);


### PR DESCRIPTION
Upgrade virksert dependencies to 1.3.3, remove virksert-move whose
functionality is included.