### PR TITLE
Feature move 3059 confidential messages should go to fiks

### DIFF
--- a/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/record/ServiceRecordService.java
+++ b/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/record/ServiceRecordService.java
@@ -38,7 +38,6 @@ import static no.difi.meldingsutveksling.serviceregistry.krr.LookupParameters.lo
 @Slf4j
 public class ServiceRecordService {
 
-    private static final String CONFIDENTIAL_PROCESS_ID = "urn:no:difi:profile:arkivmelding:taushetsbelagt:ver1.0";
     private final KontaktInfoService kontaktInfoService;
     private final ServiceregistryProperties properties;
     private final ELMALookupService elmaLookupService;
@@ -57,20 +56,19 @@ public class ServiceRecordService {
         Set<Process> arkivmeldingProcesses = processService.findAll(ProcessCategory.ARKIVMELDING);
         for (Process process : arkivmeldingProcesses) {
             createArkivmeldingServiceRecord(entityInfo, process, securityLevel)
-                    .ifPresent(serviceRecords::add);
+                .ifPresent(serviceRecords::add);
         }
         return serviceRecords;
     }
 
     public Optional<ServiceRecord> createArkivmeldingServiceRecord(EntityInfo entityInfo, Process process, Integer securityLevel) throws SecurityLevelNotFoundException, CertificateNotFoundException, SvarUtClientException {
-        boolean isConfidential = process.getIdentifier().equals(CONFIDENTIAL_PROCESS_ID);
         Set<String> processIdentifiers = getSmpRegistrations(entityInfo.getIdentifier(), Sets.newHashSet(process)).stream()
-                .map(ProcessIdentifier::getIdentifier)
-                .collect(Collectors.toSet());
+            .map(ProcessIdentifier::getIdentifier)
+            .collect(Collectors.toSet());
         if (processIdentifiers.isEmpty()) {
             if (properties.getFeature().isEnableDpfDpv()) {
                 Optional<Integer> hasSvarUt = svarUtService.hasSvarUtAdressering(entityInfo.getIdentifier(), securityLevel);
-                if (hasSvarUt.isPresent() && !isConfidential) {
+                if (hasSvarUt.isPresent()) {
                     return Optional.of(serviceRecordFactory.createDpfServiceRecord(entityInfo.getIdentifier(), process, hasSvarUt.get()));
                 } else {
                     if (securityLevel != null && securityLevel == 4) {
@@ -96,9 +94,9 @@ public class ServiceRecordService {
 
     public Optional<ServiceRecord> createServiceRecord(EntityInfo entityInfo, Process process, Integer securityLevel) throws CertificateNotFoundException {
         if (getSmpRegistrations(entityInfo.getIdentifier(), Sets.newHashSet(process))
-                .stream()
-                .map(ProcessIdentifier::getIdentifier)
-                .anyMatch(identifier -> identifier.equals(process.getIdentifier()))) {
+            .stream()
+            .map(ProcessIdentifier::getIdentifier)
+            .anyMatch(identifier -> identifier.equals(process.getIdentifier()))) {
             if (process.getCategory() == EINNSYN) {
                 return Optional.of(serviceRecordFactory.createDpeServiceRecord(entityInfo.getIdentifier(), process));
             } else if (process.getCategory() == AVTALT) {
@@ -114,8 +112,8 @@ public class ServiceRecordService {
         Set<Process> einnsynProcesses = processService.findAll(EINNSYN);
 
         Set<String> processIdentifiers = getSmpRegistrations(entityInfo.getIdentifier(), einnsynProcesses).stream()
-                .map(ProcessIdentifier::getIdentifier)
-                .collect(Collectors.toSet());
+            .map(ProcessIdentifier::getIdentifier)
+            .collect(Collectors.toSet());
 
         if (!processIdentifiers.isEmpty()) {
             for (Process p : einnsynProcesses) {
@@ -134,8 +132,8 @@ public class ServiceRecordService {
         Set<Process> avtaltProcesses = processService.findAll(AVTALT);
 
         Set<String> processIdentifiers = getSmpRegistrations(orgnr, avtaltProcesses).stream()
-                .map(ProcessIdentifier::getIdentifier)
-                .collect(Collectors.toSet());
+            .map(ProcessIdentifier::getIdentifier)
+            .collect(Collectors.toSet());
 
         for (Process p : avtaltProcesses) {
             if (processIdentifiers.contains(p.getIdentifier())) {
@@ -184,12 +182,12 @@ public class ServiceRecordService {
                     break;
                 case PRINT:
                     serviceRecordFactory.createPrintServiceRecord(identifier, onBehalfOrgnr, requestScope.getToken(), personResource, p, print)
-                            .ifPresent(serviceRecords::add);
+                        .ifPresent(serviceRecords::add);
                     break;
                 case DPV:
                 default:
                     serviceRecordFactory.createPrintServiceRecord(identifier, onBehalfOrgnr, requestScope.getToken(), personResource, p, print)
-                            .ifPresent(serviceRecords::add);
+                        .ifPresent(serviceRecords::add);
                     serviceRecords.add(serviceRecordFactory.createDigitalDpvServiceRecord(identifier, p));
             }
         }
@@ -199,9 +197,9 @@ public class ServiceRecordService {
 
     private Set<ProcessIdentifier> getSmpRegistrations(String organizationIdentifier, Set<Process> processes) {
         Set<String> documentTypeIdentifiers = processes.stream()
-                .flatMap(p -> p.getDocumentTypes().stream())
-                .map(DocumentType::getIdentifier)
-                .collect(Collectors.toSet());
+            .flatMap(p -> p.getDocumentTypes().stream())
+            .map(DocumentType::getIdentifier)
+            .collect(Collectors.toSet());
         String norwegianIcd = properties.getElma().getLookupIcd();
         return elmaLookupService.lookupRegisteredProcesses(String.format("%s:%s", norwegianIcd, organizationIdentifier), documentTypeIdentifiers);
     }

--- a/serviceregistry-server/src/test/java/no/difi/meldingsutveksling/serviceregistry/record/ServiceRecordServiceTest.java
+++ b/serviceregistry-server/src/test/java/no/difi/meldingsutveksling/serviceregistry/record/ServiceRecordServiceTest.java
@@ -72,8 +72,6 @@ public class ServiceRecordServiceTest {
 
     private static String ARKIVMELDING_PROCESS_ADMIN = "urn:no:difi:profile:arkivmelding:administrasjon:ver1.0";
     private static String ARKIVMELDING_PROCESS_SKATT = "urn:no:difi:profile:arkivmelding:skatterOgAvgifter:ver1.0";
-
-    private static String ARKIVMELDING_TAUSHETSBELAGT = "urn:no:difi:profile:arkivmelding:taushetsbelagt:ver1.0";
     private static String ARKIVMELDING_DOCTYPE = "urn:no:difi:arkivmelding:xsd::arkivmelding";
 
     private static String AVTALT_PROCESS = "urn:no:difi:profile:avtalt:avtalt:ver1.0";
@@ -92,7 +90,6 @@ public class ServiceRecordServiceTest {
 
     private static Process processAdmin;
     private static Process processAvtalt;
-    private static Process processTaushetsbelagt;
     private static Process processSkatt;
     private static Process processJournalpost;
     private static Process processInnsynskrav;
@@ -107,65 +104,59 @@ public class ServiceRecordServiceTest {
 
         // Arkivmelding
         DocumentType documentType = new DocumentType()
-                .setIdentifier(ARKIVMELDING_DOCTYPE);
+            .setIdentifier(ARKIVMELDING_DOCTYPE);
         processAdmin = new Process()
-                .setIdentifier(ARKIVMELDING_PROCESS_ADMIN)
-                .setCategory(ProcessCategory.ARKIVMELDING)
-                .setServiceCode("4192")
-                .setServiceEditionCode("270815");
+            .setIdentifier(ARKIVMELDING_PROCESS_ADMIN)
+            .setCategory(ProcessCategory.ARKIVMELDING)
+            .setServiceCode("4192")
+            .setServiceEditionCode("270815");
         processSkatt = new Process()
-                .setIdentifier(ARKIVMELDING_PROCESS_SKATT)
-                .setCategory(ProcessCategory.ARKIVMELDING)
-                .setServiceCode("4192")
-                .setServiceEditionCode("270815");
-        processTaushetsbelagt = new Process()
-                .setIdentifier(ARKIVMELDING_TAUSHETSBELAGT)
-                .setCategory(ProcessCategory.ARKIVMELDING)
-                .setServiceCode("4192")
-                .setServiceEditionCode("270815");
+            .setIdentifier(ARKIVMELDING_PROCESS_SKATT)
+            .setCategory(ProcessCategory.ARKIVMELDING)
+            .setServiceCode("4192")
+            .setServiceEditionCode("270815");
         processSkatt.setDocumentTypes(Lists.newArrayList(documentType));
-        processTaushetsbelagt.setDocumentTypes(Lists.newArrayList(documentType));
         processAdmin.setDocumentTypes(Lists.newArrayList(documentType));
-        documentType.setProcesses(Lists.newArrayList(processAdmin, processSkatt, processTaushetsbelagt));
+        documentType.setProcesses(Lists.newArrayList(processAdmin, processSkatt));
 
         // Avtalt
         DocumentType documentTypeAvtalt = new DocumentType()
-                .setIdentifier(AVTALT_DOCTYPE);
+            .setIdentifier(AVTALT_DOCTYPE);
         processAvtalt = new Process().setIdentifier(AVTALT_PROCESS)
-                .setCategory(ProcessCategory.AVTALT)
-                .setServiceCode("4192")
-                .setServiceEditionCode("270815");
+            .setCategory(ProcessCategory.AVTALT)
+            .setServiceCode("4192")
+            .setServiceEditionCode("270815");
         processAvtalt.setDocumentTypes(Lists.newArrayList(documentTypeAvtalt));
         documentTypeAvtalt.setProcesses(Lists.newArrayList(processAvtalt));
 
         // Digital
         processVedtak = new Process()
-                .setIdentifier(DIGITALPOST_PROCESS_VEDTAK)
-                .setCategory(ProcessCategory.DIGITALPOST)
-                .setDocumentTypes(Lists.newArrayList(new DocumentType().setIdentifier(DIGITALPOST_DOCTYPE_PRINT),
-                        new DocumentType().setIdentifier(DIGITALPOST_DOCTYPE_DIGITALDPV)));
+            .setIdentifier(DIGITALPOST_PROCESS_VEDTAK)
+            .setCategory(ProcessCategory.DIGITALPOST)
+            .setDocumentTypes(Lists.newArrayList(new DocumentType().setIdentifier(DIGITALPOST_DOCTYPE_PRINT),
+                new DocumentType().setIdentifier(DIGITALPOST_DOCTYPE_DIGITALDPV)));
         processInfo = new Process()
-                .setIdentifier(DIGITALPOST_PROCESS_INFO)
-                .setCategory(ProcessCategory.DIGITALPOST)
-                .setDocumentTypes(Lists.newArrayList(new DocumentType().setIdentifier(DIGITALPOST_DOCTYPE_DIGITAL)));
+            .setIdentifier(DIGITALPOST_PROCESS_INFO)
+            .setCategory(ProcessCategory.DIGITALPOST)
+            .setDocumentTypes(Lists.newArrayList(new DocumentType().setIdentifier(DIGITALPOST_DOCTYPE_DIGITAL)));
 
         // Einnsyn
         DocumentType einnsynJournalpostDocumentType = new DocumentType()
-                .setIdentifier(EINNSYN_DOCTYPE_JOURNALPOST);
+            .setIdentifier(EINNSYN_DOCTYPE_JOURNALPOST);
         processJournalpost = new Process()
-                .setIdentifier(EINNSYN_PROCESS_JOURNALPOST)
-                .setCategory(ProcessCategory.EINNSYN)
-                .setServiceCode("data")
-                .setDocumentTypes(Lists.newArrayList(einnsynJournalpostDocumentType));
+            .setIdentifier(EINNSYN_PROCESS_JOURNALPOST)
+            .setCategory(ProcessCategory.EINNSYN)
+            .setServiceCode("data")
+            .setDocumentTypes(Lists.newArrayList(einnsynJournalpostDocumentType));
         einnsynJournalpostDocumentType.setProcesses(Lists.newArrayList(processJournalpost));
 
         DocumentType einnsynInnsynskravDocumentType = new DocumentType()
-                .setIdentifier(EINNSYN_DOCTYPE_INNSYNSKRAV);
+            .setIdentifier(EINNSYN_DOCTYPE_INNSYNSKRAV);
         processInnsynskrav = new Process()
-                .setIdentifier(EINNSYN_PROCESS_INNSYNSKRAV)
-                .setCategory(ProcessCategory.EINNSYN)
-                .setServiceCode("innsyn")
-                .setDocumentTypes(Lists.newArrayList(einnsynInnsynskravDocumentType));
+            .setIdentifier(EINNSYN_PROCESS_INNSYNSKRAV)
+            .setCategory(ProcessCategory.EINNSYN)
+            .setServiceCode("innsyn")
+            .setDocumentTypes(Lists.newArrayList(einnsynInnsynskravDocumentType));
         einnsynInnsynskravDocumentType.setProcesses(Lists.newArrayList(processInnsynskrav));
     }
 
@@ -185,17 +176,17 @@ public class ServiceRecordServiceTest {
 
     private void lookupServiceReturnsArkivmeldingAdminProcess() {
         when(lookupService.lookupRegisteredProcesses(eq(String.format("%s:%s", ELMA_LOOKUP_ICD, ORGNR)), anySet()))
-                .thenReturn(Sets.newHashSet(ProcessIdentifier.of(ARKIVMELDING_PROCESS_ADMIN)));
+            .thenReturn(Sets.newHashSet(ProcessIdentifier.of(ARKIVMELDING_PROCESS_ADMIN)));
     }
 
     private void lookupServiceReturnsAvtaltProcess() {
         when(lookupService.lookupRegisteredProcesses(eq(String.format("%s:%s", ELMA_LOOKUP_ICD, ORGNR)), anySet()))
-                .thenReturn(Sets.newHashSet(ProcessIdentifier.of(AVTALT_PROCESS)));
+            .thenReturn(Sets.newHashSet(ProcessIdentifier.of(AVTALT_PROCESS)));
     }
 
     private void lookupServiceReturnsEinnsynJournalpostProcesses() {
         when(lookupService.lookupRegisteredProcesses(eq(String.format("%s:%s", ELMA_LOOKUP_ICD, ORGNR)), anySet()))
-                .thenReturn(Sets.newHashSet(ProcessIdentifier.of(EINNSYN_PROCESS_JOURNALPOST), ProcessIdentifier.of(EINNSYN_PROCESS_INNSYNSKRAV)));
+            .thenReturn(Sets.newHashSet(ProcessIdentifier.of(EINNSYN_PROCESS_JOURNALPOST), ProcessIdentifier.of(EINNSYN_PROCESS_INNSYNSKRAV)));
     }
 
     @SneakyThrows
@@ -203,7 +194,7 @@ public class ServiceRecordServiceTest {
     public void createArkivmeldingServiceRecord_IdentifierHasSvarUtRegistrationOnDifferentSecurityLevel_ShouldThrowDedicatedException() {
         enablePropertyEnableDpvDpf();
         when(svarUtService.hasSvarUtAdressering(anyString(), any())).thenReturn(Optional.empty());
-        assertThrows(SecurityLevelNotFoundException.class, () -> service.createArkivmeldingServiceRecord(ORGNR_ORG, processAdmin, 4));
+        assertThrows(SecurityLevelNotFoundException.class, () -> service.createArkivmeldingServiceRecord(ORGNR_ORG, mock(Process.class), 4));
     }
 
     @SneakyThrows
@@ -305,7 +296,7 @@ public class ServiceRecordServiceTest {
         enablePropertyEnableDpvDpf();
         when(processService.findAll(ProcessCategory.ARKIVMELDING)).thenReturn(Sets.newHashSet(processAdmin, processSkatt));
         when(svarUtService.hasSvarUtAdressering(eq(ORGNR_FIKS), any()))
-                .thenThrow(new SvarUtClientException(new RuntimeException("service unavailable")));
+            .thenThrow(new SvarUtClientException(new RuntimeException("service unavailable")));
         assertThrows(SvarUtClientException.class, () -> service.createArkivmeldingServiceRecords(ORGNR_FIKS_KOMM, 3));
     }
 
@@ -367,22 +358,11 @@ public class ServiceRecordServiceTest {
 
         when(kontaktInfoService.getCitizenInfo(any(LookupParameters.class))).thenReturn(personResource);
         when(serviceRecordFactory.createPrintServiceRecord(eq(PERSONNUMMER), eq(ORGNR), any(), eq(personResource), eq(processVedtak), eq(true)))
-                .thenReturn(Optional.of(mock(ServiceRecord.class)));
+            .thenReturn(Optional.of(mock(ServiceRecord.class)));
         when(serviceRecordFactory.createDigitalDpvServiceRecord(PERSONNUMMER, processVedtak))
-                .thenReturn(mock(ServiceRecord.class));
+            .thenReturn(mock(ServiceRecord.class));
 
         assertEquals(2, service.createDigitalpostServiceRecords(PERSONNUMMER, ORGNR, true, processVedtak).size());
     }
 
-    @Test
-    void createArkivmeldingServiceRecord_MessageIsConfidential_ShouldNotBeSentToSvarut() throws SvarUtClientException, CertificateNotFoundException, SecurityLevelNotFoundException {
-        enablePropertyEnableDpvDpf();
-        when(svarUtService.hasSvarUtAdressering(anyString(), eq(3))).thenReturn(Optional.of(3));
-        when(serviceRecordFactory.createDpvServiceRecord(anyString(), any(Process.class))).thenReturn(mock(ServiceRecord.class));
-
-        var record = service.createArkivmeldingServiceRecord(ORGNR_ORG, processTaushetsbelagt, 3);
-
-        assertTrue(record.isPresent());
-        verify(serviceRecordFactory).createDpvServiceRecord(ORGNR, processTaushetsbelagt);
-    }
 }


### PR DESCRIPTION
Denne PR-en reverterar commitar som hindrar tausheitsbelagte meldingar i å verta sende til FIKS. Tausheitsbelagt meldingsutveksling er no inne i varmen både hjå oss (DPO) og KS (DPF).