### PR TITLE
chore: MOVE-3466: Update test sign certificate

### DIFF
--- a/serviceregistry-server/src/main/resources/application-dev.properties
+++ b/serviceregistry-server/src/main/resources/application-dev.properties
@@ -8,9 +8,6 @@ difi.move.dpi.endpointURL=https://qaoffentlig.meldingsformidler.digipost.no/api/
 difi.move.krr.mp-endpoint-uri=https://test.kontaktregisteret.no/rest/v1/personer
 difi.move.krr.mp-dsf-endpoint-uri=https://test.kontaktregisteret.no/rest/v1/mf/personer
 
-difi.move.sign.keystore.alias=digdir-test-sign
-difi.move.sign.keystore.password=changeit
-
 app.logger.destination=test-stream-meldingsutveksling.dificloud.net:443
 logging.level.org.springframework.ws.client.MessageTracing=TRACE
 logging.level.org.springframework.ws.server.MessageTracing=TRACE

--- a/serviceregistry-server/src/main/resources/application-yt.properties
+++ b/serviceregistry-server/src/main/resources/application-yt.properties
@@ -10,9 +10,6 @@ difi.move.krr.mp-dsf-endpoint-uri=https://krr-yt2.digdir.eon.no/rest/v1/mf/perso
 
 difi.move.auth.maskinporten-issuer=https://yt2.maskinporten.no/
 
-difi.move.sign.keystore.alias=digdir-test-sign
-difi.move.sign.keystore.password=changeit
-
 app.logger.destination=test-stream-meldingsutveksling.dificloud.net:443
 logging.level.*=WARNING
 logging.level.no.difi=INFO

--- a/serviceregistry-server/src/main/resources/application.properties
+++ b/serviceregistry-server/src/main/resources/application.properties
@@ -31,10 +31,10 @@ difi.move.virksert.icd=0192
 difi.move.virksert.processes.dpo=cenbii-procid-ubl::urn:no:difi:profile:dpo:ver1.0
 difi.move.virksert.processes.dpe=cenbii-procid-ubl::urn:no:difi:profile:dpe:ver1.0
 
-difi.move.sign.keystore.path=cloud:digdir-test-sign.jks
-difi.move.sign.keystore.alias=digdir-test-sign
+difi.move.sign.keystore.path=cloud:eformidling-test-sign.jks
+difi.move.sign.keystore.alias=digdir-test-eformidling
 difi.move.sign.keystore.type=JKS
-difi.move.sign.keystore.password=changeit
+difi.move.sign.keystore.password=MeldingTeHumor2023!
 
 difi.move.datahotell.endpointURL=https://hotell.difi.no/
 


### PR DESCRIPTION
- Reference new test signing certificate in stead of predecessor.