### PR TITLE
Move 4241 konvensjonell loggtilnærming i service registry

### DIFF
--- a/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/client/DefaultFregGatewayClient.java
+++ b/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/client/DefaultFregGatewayClient.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Profile("production")
 public class DefaultFregGatewayClient implements FregGatewayClient {
-    protected final ServiceregistryProperties properties;
+    private final ServiceregistryProperties properties;
 
     @Autowired
     @Qualifier("fregGatewayRestTemplate")
@@ -27,17 +27,21 @@ public class DefaultFregGatewayClient implements FregGatewayClient {
     @Override
     public Optional<FregGatewayEntity.Address.Response> getPersonAdress(String pid) {
         try {
-            String url = properties.getFreg().getEndpointURL() + "person/personadresse/" + pid;
-            ResponseEntity<FregGatewayEntity.Address.Response> response = restTemplate.getForEntity(
-                    url,
-                    FregGatewayEntity.Address.Response.class,
-                    pid);
-            FregGatewayEntity.Address.Response responseBody = response.getBody();
-            return Optional.of(responseBody);
+            return getAddressFromFreg(pid);
         } catch (HttpClientErrorException e) {
             return Optional.empty();
         }
 
+    }
+
+    protected Optional<FregGatewayEntity.Address.Response> getAddressFromFreg(String pid) throws HttpClientErrorException {
+        String url = properties.getFreg().getEndpointURL() + "person/personadresse/" + pid;
+        ResponseEntity<FregGatewayEntity.Address.Response> response = restTemplate.getForEntity(
+                url,
+                FregGatewayEntity.Address.Response.class,
+                pid);
+        FregGatewayEntity.Address.Response responseBody = response.getBody();
+        return Optional.of(responseBody);
     }
 }
 

--- a/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/client/DefaultFregGatewayClient.java
+++ b/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/client/DefaultFregGatewayClient.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Optional;
@@ -17,7 +18,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Profile("production")
 public class DefaultFregGatewayClient implements FregGatewayClient {
-    private final ServiceregistryProperties properties;
+    protected final ServiceregistryProperties properties;
 
     @Autowired
     @Qualifier("fregGatewayRestTemplate")
@@ -25,13 +26,18 @@ public class DefaultFregGatewayClient implements FregGatewayClient {
 
     @Override
     public Optional<FregGatewayEntity.Address.Response> getPersonAdress(String pid) {
-        String url = properties.getFreg().getEndpointURL() + "person/personadresse/" + pid;
-        ResponseEntity<FregGatewayEntity.Address.Response> response = restTemplate.getForEntity(
-                url,
-                FregGatewayEntity.Address.Response.class,
-                pid);
-        FregGatewayEntity.Address.Response responseBody = response.getBody();
-        return Optional.of(responseBody);
+        try {
+            String url = properties.getFreg().getEndpointURL() + "person/personadresse/" + pid;
+            ResponseEntity<FregGatewayEntity.Address.Response> response = restTemplate.getForEntity(
+                    url,
+                    FregGatewayEntity.Address.Response.class,
+                    pid);
+            FregGatewayEntity.Address.Response responseBody = response.getBody();
+            return Optional.of(responseBody);
+        } catch (HttpClientErrorException e) {
+            return Optional.empty();
+        }
+
     }
 }
 

--- a/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/client/DefaultFregGatewayClient.java
+++ b/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/client/DefaultFregGatewayClient.java
@@ -28,7 +28,7 @@ public class DefaultFregGatewayClient implements FregGatewayClient {
     public Optional<FregGatewayEntity.Address.Response> getPersonAdress(String pid) {
         try {
             return getAddressFromFreg(pid);
-        } catch (HttpClientErrorException e) {
+        } catch (HttpClientErrorException.NotFound e) {
             return Optional.empty();
         }
 

--- a/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/mock/DefaultFregClientWithMock.java
+++ b/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/mock/DefaultFregClientWithMock.java
@@ -4,9 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 import no.difi.meldingsutveksling.serviceregistry.config.ServiceregistryProperties;
 import no.difi.meldingsutveksling.serviceregistry.freg.client.DefaultFregGatewayClient;
 import no.difi.meldingsutveksling.serviceregistry.freg.domain.FregGatewayEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +20,9 @@ import java.util.Optional;
 @Slf4j
 @Profile({"dev-local", "dev", "test", "yt"})
 public class DefaultFregClientWithMock extends DefaultFregGatewayClient {
+    @Autowired
+    @Qualifier("fregGatewayRestTemplate")
+    private RestTemplate restTemplate;
 
     public DefaultFregClientWithMock(ServiceregistryProperties properties) {
         super(properties);
@@ -24,7 +31,13 @@ public class DefaultFregClientWithMock extends DefaultFregGatewayClient {
     @Override
     public Optional<FregGatewayEntity.Address.Response> getPersonAdress(String pid) {
         try {
-            return super.getPersonAdress(pid);
+            String url = properties.getFreg().getEndpointURL() + "person/personadresse/" + pid;
+            ResponseEntity<FregGatewayEntity.Address.Response> response = restTemplate.getForEntity(
+                    url,
+                    FregGatewayEntity.Address.Response.class,
+                    pid);
+            FregGatewayEntity.Address.Response responseBody = response.getBody();
+            return Optional.of(responseBody);
         } catch (HttpClientErrorException.NotFound e) {
             log.info("User not found in Tenor testdatasøk. Returning mock user", e);
             return Optional.of(FregGatewayEntity.Address.Response.builder()

--- a/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/mock/DefaultFregClientWithMock.java
+++ b/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/mock/DefaultFregClientWithMock.java
@@ -4,13 +4,9 @@ import lombok.extern.slf4j.Slf4j;
 import no.difi.meldingsutveksling.serviceregistry.config.ServiceregistryProperties;
 import no.difi.meldingsutveksling.serviceregistry.freg.client.DefaultFregGatewayClient;
 import no.difi.meldingsutveksling.serviceregistry.freg.domain.FregGatewayEntity;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,9 +16,6 @@ import java.util.Optional;
 @Slf4j
 @Profile({"dev-local", "dev", "test", "yt"})
 public class DefaultFregClientWithMock extends DefaultFregGatewayClient {
-    @Autowired
-    @Qualifier("fregGatewayRestTemplate")
-    private RestTemplate restTemplate;
 
     public DefaultFregClientWithMock(ServiceregistryProperties properties) {
         super(properties);
@@ -31,13 +24,7 @@ public class DefaultFregClientWithMock extends DefaultFregGatewayClient {
     @Override
     public Optional<FregGatewayEntity.Address.Response> getPersonAdress(String pid) {
         try {
-            String url = properties.getFreg().getEndpointURL() + "person/personadresse/" + pid;
-            ResponseEntity<FregGatewayEntity.Address.Response> response = restTemplate.getForEntity(
-                    url,
-                    FregGatewayEntity.Address.Response.class,
-                    pid);
-            FregGatewayEntity.Address.Response responseBody = response.getBody();
-            return Optional.of(responseBody);
+            return super.getAddressFromFreg(pid);
         } catch (HttpClientErrorException.NotFound e) {
             log.info("User {} not found in Tenor testdatasøk. Returning mock user", pid);
             return Optional.of(FregGatewayEntity.Address.Response.builder()

--- a/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/mock/DefaultFregClientWithMock.java
+++ b/freg-gateway-client/src/main/java/no/difi/meldingsutveksling/serviceregistry/freg/mock/DefaultFregClientWithMock.java
@@ -39,7 +39,7 @@ public class DefaultFregClientWithMock extends DefaultFregGatewayClient {
             FregGatewayEntity.Address.Response responseBody = response.getBody();
             return Optional.of(responseBody);
         } catch (HttpClientErrorException.NotFound e) {
-            log.info("User not found in Tenor testdatasøk. Returning mock user", e);
+            log.info("User {} not found in Tenor testdatasøk. Returning mock user", pid);
             return Optional.of(FregGatewayEntity.Address.Response.builder()
                     .personIdentifikator(pid)
                     .navn(FregGatewayEntity.Address.Navn.builder()


### PR DESCRIPTION
Er ikkje heilt sikker på endringen av private til protected i DefaultFregGatewayClient, men einaste alternative løsningen eg fann var lika rar. Om eg forstår rett skal berre ein av DefaultFregGatewayClient eller DefaultFregClientWithMock eksistera uansett, styrt av kå slags profil ein køyrer applikasjonen opp med, so eg kan ikkje tenka meg at det skulle føra til noke rart.

Fjerna og info-logging av 404 stack-trace frå FREG-gateway i ikkje-prod miljøa og la heller til logging av det personnummeret ein søkte etter der (personnummeret var i stack-tracen som eg fjerna).