### PR TITLE
MOVE-4307 Remove mysql-connector-j dependency

### DIFF
--- a/serviceregistry-server/pom.xml
+++ b/serviceregistry-server/pom.xml
@@ -264,10 +264,6 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>


### PR DESCRIPTION
MariaDB should currently be in use in every environment.