### PR TITLE
MOVE-4378 Update Virksert-Client to 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <move-common.version>2.0.0-SNAPSHOT</move-common.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
-        <virksert.version>2.0.0-SNAPSHOT</virksert.version>
+        <virksert.version>2.0.4</virksert.version>
 
         <bouncycastle.version>1.70</bouncycastle.version>
 


### PR DESCRIPTION
Also, nice to no longer be dependent on SNAPSHOT version.