### PR TITLE
MOVE-3675

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <move-common.version>2.0.0-SNAPSHOT</move-common.version>
+        <move-common.version>2.0.1</move-common.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
         <virksert.version>2.0.4</virksert.version>


### PR DESCRIPTION
deprecated spring-security-oauth2 came from move-common, upgraded version of move-common to newer which do not have spring-security-oauth2